### PR TITLE
fix description error

### DIFF
--- a/aspnetcore/tutorials/razor-pages/sql.md
+++ b/aspnetcore/tutorials/razor-pages/sql.md
@@ -52,7 +52,7 @@ ASP.NET Core [組態](xref:fundamentals/configuration/index)系統會讀取 `Con
 
 ## <a name="sql-server-express-localdb"></a>SQL Server Express LocalDB
 
-LocalDB 為輕量版的 SQL Server Express 資料庫引擎，鎖定程式開發為其目標。 LocalDB 會依需求啟動，並以使用者模式執行，因此沒有複雜的組態。 LocalDB 資料庫預設會在 `*.mdf` 目錄中建立 `C:\Users\<user>\` 檔案。
+LocalDB 為輕量版的 SQL Server Express 資料庫引擎，鎖定程式開發為其目標。 LocalDB 會依需求啟動，並以使用者模式執行，因此沒有複雜的組態。 LocalDB 資料庫預設會在 `C:\Users\<user>\` 目錄中建立 `*.mdf` 檔案。
 
 <a name="ssox"></a>
 * 從 [檢視] 功能表中，開啟 [SQL Server 物件總管] (SSOX)。


### PR DESCRIPTION
Original English is: By default, LocalDB database creates *.mdf files in the C:\Users\<user>\ directory

So the description is reversed

一些有助於提出建議的實用資訊：
1.請參閱 Microsoft Style Guide (Microsoft 樣式指南) 之 [Quick Start Localization Style Guides(本地化樣式入門指南)](https://docs.microsoft.com/globalization/localization/styleguides) 中的 **top 10 most important rules** (10 大重要規則)。
2.前往 [Microsoft 語言入口網站](https://www.microsoft.com/zh-tw/language)，查看不同 Microsoft 產品的 **標準化詞彙翻譯**。
